### PR TITLE
fix: add s3 bucket level permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ As this feature is released as a beta version, users are requested to perform th
                 "s3:Get*",
                 "s3:List*"
             ],
-      "Resource": [ "arn:aws:s3:::<s3-bucket>/*/account_id=<firebolt-account-id>/*"
+      "Resource": [ 
+        "arn:aws:s3:::<s3-bucket>",
+        "arn:aws:s3:::<s3-bucket>/*/account_id=<firebolt-account-id>/*"
             ]
         }
     ]


### PR DESCRIPTION
According to recent experience we need an s3 bucket in the list of resources.